### PR TITLE
feat: Migrate from Google Maps API to Leaflet.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,31 @@
-# Package Tracking SPA (Enhanced)
+# Package Tracking SPA (Leaflet.js Version)
 
-This is a Single Page Application (SPA) designed for a business owner to track driver locations, manage package assignments, and get simulated notifications for package pickups. It operates entirely within the browser, using JavaScript to simulate backend functionalities.
+This is a Single Page Application (SPA) designed for a business owner to track driver locations, manage package assignments, and get simulated notifications for package pickups. It operates entirely within the browser, using **Leaflet.js** for mapping and JavaScript to simulate backend functionalities.
 
-## Phase 2 Enhancements
+## Phase 4: Migration to Leaflet.js
+This version has been migrated from Google Maps API to Leaflet.js, using OpenStreetMap for map tiles and Nominatim for geocoding.
 
+## Key Features
+*   **Mapping:** Uses Leaflet.js with OpenStreetMap tiles.
 *   **Tabbed Interface:** "Overall Dashboard" and "Drivers View".
-*   **Enhanced Package Information:** Packages now include an auto-generated unique `packageCode`, recipient name, and delivery address.
-*   **Predefined & Custom Pickup Locations:** Select from a dropdown of predefined locations or enter custom latitude/longitude.
+*   **Enhanced Package Information:** Packages include an auto-generated unique `packageCode`, recipient name, and delivery address.
+*   **Predefined & Custom Pickup Locations:** Select from a dropdown of predefined locations or enter a ZIP code (and country) for custom locations, which are then geocoded using Nominatim.
 *   **Package Assignment & Status:**
     *   Packages have statuses: 'pending', 'assigned', 'accepted_by_driver', 'declined_by_driver'.
     *   Assign 'pending' packages to available drivers directly from the main dashboard.
 *   **Driver-Specific View:**
     *   Select a driver to see their location centered on a dedicated map.
     *   View a list of packages assigned to the selected driver.
-    *   Conceptually "Accept" or "Decline" assigned packages (simulating driver actions).
-*   **Simulated Telegram Notifications:** When a package is assigned to a driver, a notification is simulated in the browser's console, including package details and a Google Maps link to the pickup location.
-*   **Simulated Backend:** Data (drivers, packages, predefined locations) is managed in memory by `backend.js` and resets on page reload.
-
-## Core Features (from Phase 1)
-
+    *   Conceptually "Accept" or "Decline" assigned packages.
+*   **Simulated Telegram Notifications:** When a package is assigned, a notification is simulated in the browser's console.
+*   **Simulated Backend:** Data is managed in memory by `backend.js` and resets on page reload.
 *   **Driver Tracking:** Displays driver locations on a map in (simulated) real-time.
-*   **Map Integration:** Uses Google Maps to visualize locations.
+
 
 ## Prerequisites
 
 1.  **Web Browser:** A modern web browser (e.g., Chrome, Firefox, Safari, Edge).
-2.  **Google Maps API Key:** You **must** have a valid Google Maps JavaScript API key.
-    *   Go to the [Google Cloud Console](https://console.cloud.google.com/).
-    *   Create a new project or select an existing one.
-    *   Enable the "Maps JavaScript API".
-    *   Under "Credentials," create an API key.
-    *   **Important:** Restrict your API key to prevent unauthorized use (e.g., by HTTP referrers for your specific domain if deploying, or keep it for localhost development only if not deploying).
+2.  **Internet Connection:** Required to load Leaflet.js, OpenStreetMap tiles, and for Nominatim geocoding requests.
 
 ## Setup and Running the Application
 
@@ -40,54 +35,46 @@ This is a Single Page Application (SPA) designed for a business owner to track d
     *   `style.css`
     *   `app.js`
     *   `backend.js` (simulates backend operations)
+    *(Leaflet.js library is included via CDN in `index.html` - no separate installation needed).*
 
-2.  **Add Your Google Maps API Key:**
-    *   Open `index.html` in a text editor.
-    *   Find the following line:
-        ```html
-        <!-- <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap" async defer></script> -->
-        ```
-    *   Uncomment it by removing `<!--` and `-->`.
-    *   Replace `YOUR_API_KEY` with your actual Google Maps API key. The line should look like this:
-        ```html
-        <script src="https://maps.googleapis.com/maps/api/js?key=ACTUAL_KEY_HERE&callback=initMap" async defer></script>
-        ```
-
-3.  **Open in Browser:**
+2.  **Open in Browser:**
     *   Open the `index.html` file directly in your web browser (e.g., by double-clicking it or using "File > Open" in your browser).
 
 ## How to Use
 
 ### Overall Dashboard Tab
 
-*   **Viewing Drivers & HQ:** The main map shows simulated driver locations (blue markers moving randomly) and the Business HQ.
+*   **Viewing Drivers & HQ:** The main map shows simulated driver locations and the Business HQ.
 *   **Adding a New Package:**
     1.  Use the "New Package" form on the right.
     2.  Enter "Description/Notes" (optional).
     3.  Enter "Recipient Name" and "Delivery Address" (required).
     4.  Select a "Pickup Location" from the dropdown. Sample locations are provided.
-    5.  If "Custom Location" is selected, the latitude and longitude fields will appear; fill them in.
+    5.  If "Custom Location" is selected, input fields for "Pickup ZIP Code" and "Country" will appear. Enter the relevant ZIP code (the country defaults to "Moldova" but can be changed). The system will use **Nominatim (OpenStreetMap's geocoding service)** to find the coordinates for this location.
     6.  Click "Add Package".
-    7.  The package will appear on the map (yellow marker) and in the "Pending Pickups" list with status 'pending'.
+    7.  The package will appear on the map and in the "Pending Pickups" list with status 'pending'.
 *   **Assigning a Package:**
     1.  In the "Pending Pickups" list, find a package with status 'pending'.
     2.  Click the "Assign to Driver" button next to it.
-    3.  When prompted, enter the numerical ID of an existing driver (e.g., 1, 2, or 3 for the mock drivers).
-    4.  If successful, the package status will update to 'assigned', the assigned driver's name will appear, and a simulated Telegram notification will be logged in the browser console.
+    3.  When prompted, enter the numerical ID of an existing driver.
+    4.  If successful, the package status updates, and a simulated Telegram notification is logged.
 
 ### Drivers View Tab
-
+(This section remains largely the same in functionality)
 1.  Click the "Drivers View" tab.
-2.  **Select a Driver:** Choose a driver from the "Select Driver" dropdown.
-    *   The map in this view will center on the selected driver's current location.
-    *   The panel on the right ("Packages for Selected Driver") will list packages currently assigned to this driver, along with their status.
+2.  **Select a Driver:** Choose a driver from the dropdown.
+    *   The map centers on the selected driver.
+    *   The panel lists packages assigned to this driver.
 3.  **Simulating Driver Actions (Accept/Decline):**
-    *   If a package is listed with status 'assigned', "Accept" and "Decline" buttons will appear next to it.
-    *   Clicking "Accept" will change the package status to 'accepted_by_driver'.
-    *   Clicking "Decline" will change the package status to 'declined_by_driver' and unassign it from the driver (it will then need attention in the main dashboard).
-    *   These actions are conceptual representations of what a driver might do via a real Telegram bot.
+    *   "Accept" or "Decline" assigned packages.
 
-### Data Persistence
+## Technology & Credits
+
+*   **Mapping Library:** [Leaflet.js](https://leafletjs.com/) - An open-source JavaScript library for interactive maps.
+*   **Map Tiles:** Map tiles are provided by &copy; [OpenStreetMap contributors](https://www.openstreetmap.org/copyright).
+*   **Geocoding Service:** Custom ZIP code lookups are performed using [Nominatim](https://nominatim.openstreetmap.org/), a search engine for OpenStreetMap data. (Please respect Nominatim's [Usage Policy](https://operations.osmfoundation.org/policies/nominatim/) if adapting this code for heavier use; a User-Agent is set in the requests).
+
+## Data Persistence
 
 *   All driver, package, and location data is stored in-memory while the page is open. **Reloading the page will reset all data to its initial state.**
 *   The Telegram notifications are simulations logged to the browser's developer console.

--- a/index.html
+++ b/index.html
@@ -5,8 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Package Tracking SPA</title>
     <link rel="stylesheet" href="style.css">
-    <!-- Placeholder for Google Maps API script -->
+    <!-- Google Maps API script (removed or commented out) -->
     <!-- <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap" async defer></script> -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 </head>
 <body>
     <header>
@@ -45,14 +46,17 @@
                             <select id="pickup-location-select" name="pickup-location-select"></select>
                         </div>
                         <div id="custom-location-fields" style="display: none;"> <!-- Initially hidden -->
+                    <!-- This is inside the <div id="custom-location-fields" style="display: none;"> -->
                             <div>
-                                <label for="pickup-lat">Pickup Latitude:</label>
-                                <input type="text" id="pickup-lat" name="pickup-lat"> <!-- Not required initially -->
+                        <label for="pickup-zip-code">Pickup ZIP Code:</label>
+                        <input type="text" id="pickup-zip-code" name="pickup-zip-code">
                             </div>
                             <div>
-                                <label for="pickup-lng">Pickup Longitude:</label>
-                                <input type="text" id="pickup-lng" name="pickup-lng"> <!-- Not required initially -->
+                        <label for="pickup-country">Country (for ZIP Code):</label>
+                        <input type="text" id="pickup-country" name="pickup-country" value="Moldova"> 
+                        <!-- Defaulting to Moldova, user can change if needed -->
                             </div>
+                    <!-- End of content for #custom-location-fields -->
                         </div>
                         <button type="submit">Add Package</button>
                     </form>
@@ -89,6 +93,7 @@
         <p>&copy; 2023 Package Trans</p>
     </footer>
 
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="backend.js"></script>
     <script src="app.js"></script>
 </body>


### PR DESCRIPTION
Replaces all Google Maps API functionality with Leaflet.js, OpenStreetMap tiles, and Nominatim geocoding.

Key changes:
- Replaced Google Maps API script with Leaflet.js library in `index.html`.
- Updated map initialization (`initMap`, `initDriverMap`) in `app.js` to use Leaflet and OpenStreetMap tile layers.
- Re-implemented all marker logic (`addMarker`, `initializeDrivers`, `simulateDriverMovement`, etc.) using Leaflet's API.
- Replaced Google Geocoding with Nominatim (via `fetch` API) for ZIP code-based custom location searches.
- Ensured consistent location data handling (`{lat, lng}`).
- Updated `README.md` to remove Google Maps prerequisites and reflect the new Leaflet.js stack, including OpenStreetMap and Nominatim credits and usage notes.